### PR TITLE
Fixing Argument Error in run_nerf.py and adding gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#IntelliJ
+.idea/

--- a/configs/chairs.yaml
+++ b/configs/chairs.yaml
@@ -1,0 +1,11 @@
+expname: carla_128
+data:
+  imsize: 600
+  datadir: data/carla
+  type: carla
+  radius: 9.6
+  near: 9
+  far: 10
+  fov: 30.0
+  vmin: 0.1 # 50 deg - todo: need to do proper calculation from deg to number here.
+  vmax: 0.32898992833716556 # 70 deg

--- a/submodules/nerf_pytorch/run_nerf.py
+++ b/submodules/nerf_pytorch/run_nerf.py
@@ -365,7 +365,7 @@ def config_parser():
     parser.add_argument("--netwidth", type=int, default=256, help='channels per layer')
     parser.add_argument("--netdepth_fine", type=int, default=8, help='layers in fine network')
     parser.add_argument("--netwidth_fine", type=int, default=256, help='channels per layer in fine network')
-    parser.add_argument("--N_samples", type=int, default=32*32*4, help='batch size (number of random rays per gradient step)')
+    parser.add_argument("--N_rand", type=int, default=32*32*4, help='batch size (number of random rays per gradient step)')
     parser.add_argument("--lrate", type=float, default=5e-4, help='learning rate')
     parser.add_argument("--lrate_decay", type=int, default=250, help='exponential learning rate decay (in 1000 steps)')
     parser.add_argument("--chunk", type=int, default=1024*32, help='number of rays processed in parallel, decrease if running out of memory')


### PR DESCRIPTION
As pointed out in one of the issues. The below argument is duplicated, and causes an error.
graf/submodules/nerf_pytorch/run_nerf.py
Line 368 in eaa2d6e
`
parser.add_argument("--N_samples", type=int, default=32*32*4, help='batch size (number of random rays per gradient step)') 
`

It should be
`
parser.add_argument ("- N_rand", type = int, default = 32 * 32 * 4, help = 'batch size (number of random rays per gradient step)')
`